### PR TITLE
13 implement interactive object options

### DIFF
--- a/Assets/Scenes/SampleScene.unity
+++ b/Assets/Scenes/SampleScene.unity
@@ -2713,7 +2713,6 @@ MonoBehaviour:
   defaultMaterial: {fileID: 2100000, guid: a2d641af4179722418e3a9cb210fdcf4, type: 2}
   objectText: {fileID: 444979688}
   interactionMessage: Chest. Press 'E' to interact.
-  puzzlePanel: {fileID: 1682501510}
 --- !u!65 &1057622123
 BoxCollider:
   m_ObjectHideFlags: 0
@@ -3203,7 +3202,6 @@ MonoBehaviour:
   defaultMaterial: {fileID: 2100000, guid: a2d641af4179722418e3a9cb210fdcf4, type: 2}
   objectText: {fileID: 1728394554}
   interactionMessage: Painting. Press 'E' to interact.
-  puzzlePanel: {fileID: 0}
 --- !u!65 &1407658701
 BoxCollider:
   m_ObjectHideFlags: 0
@@ -3554,7 +3552,7 @@ MonoBehaviour:
     m_HorizontalOverflow: 0
     m_VerticalOverflow: 0
     m_LineSpacing: 1
-  m_Text: (Chest Puzzle)
+  m_Text: Chest Puzzle
 --- !u!222 &1573886527
 CanvasRenderer:
   m_ObjectHideFlags: 0
@@ -3611,7 +3609,7 @@ GameObject:
   - component: {fileID: 1634086998}
   - component: {fileID: 1634086997}
   m_Layer: 5
-  m_Name: Button
+  m_Name: CloseButton
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -3768,7 +3766,7 @@ RectTransform:
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 500, y: 500}
+  m_SizeDelta: {x: 400, y: 200}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1682501512
 MonoBehaviour:
@@ -4816,7 +4814,6 @@ MonoBehaviour:
   defaultMaterial: {fileID: 2100000, guid: a2d641af4179722418e3a9cb210fdcf4, type: 2}
   objectText: {fileID: 544447400}
   interactionMessage: Bookshelf. Press 'E' to interact.
-  puzzlePanel: {fileID: 0}
 --- !u!65 &2064597059
 BoxCollider:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/TriggerInteraction.cs
+++ b/Assets/Scripts/TriggerInteraction.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections;
 using System.Collections.Generic;
 using TMPro;
@@ -9,47 +8,25 @@ using UnityEngine;
 public class TriggerInteraction : MonoBehaviour
 {
     public GameObject player; // Player object
-    public GameObject interactiveObject; // Object to highlight.
+    public GameObject interactiveObject; // Object you want to change the color of.
     public Material highlightMaterial; // highlight material when player is near object
     public Material defaultMaterial;
     public TMP_Text objectText; // text for interaction prompts
-    public string interactionMessage; // custom message to display
-    public GameObject puzzlePanel; // UI panel of the puzzle
-    private bool isPlayerNear = false; // to check if player is in range
+    public string interactionMessage; // custom prompt message to display
+
+
 
     private void Start()
     {
         objectText.text = string.Empty;
-        puzzlePanel.SetActive(false);        // ensure panel is hidden at start
     }
 
     void OnTriggerEnter(Collider other)
     {
-        /*
         if (other.gameObject == player)
         {
             interactiveObject.GetComponent<Renderer>().material = highlightMaterial;
-
-            if (objectText.name == "BookshelfText")
-            {
-                objectText.text = "Bookshelf. Press 'E' to interact";
-            }
-            else if (objectText.name == "PaintingText")
-            {
-                objectText.text = "Painting. Press 'E' to interact";
-            }
-            else if (objectText.name == "ChestText")
-            {
-                objectText.text = "Chest. Press 'E' to interact";
-            }
-        }          // replaced this code with the code below as it is shorter
-        */
-
-        if (other.gameObject == player) 
-        {
-            interactiveObject.GetComponent<Renderer>().material = highlightMaterial;
-            objectText.text = interactionMessage;
-            isPlayerNear = true;    
+            objectText.text = interactionMessage;   // display the custom message prompt
         }
     }
 
@@ -59,17 +36,6 @@ public class TriggerInteraction : MonoBehaviour
         {
             interactiveObject.GetComponent<Renderer>().material = defaultMaterial;
             objectText.text = string.Empty;
-            isPlayerNear = false;
-        }
-    }
-
-    void Update()
-    {
-        if (isPlayerNear && Input.GetKeyDown(KeyCode.E)) // check if player is near and presses 'E'
-        {
-            Debug.Log("Interaction with object: " + interactiveObject.name); // to check if prompt is working 
-            puzzlePanel.SetActive(true);   // display the puzzle panel
-
         }
     }
 }


### PR DESCRIPTION
Added the trigger point for the chest object aswell as the text object ChestText so that the prompt will be displayed for chest object:
![image](https://github.com/user-attachments/assets/ee9b1c5b-ef1e-4ae0-bb15-8776a65c899a)

All interactive objects now correctly display prompts. Prompts do not work yet. TriggerInteraction.cs modified to improve code but does not implement any key prompt interaction yet. 

ChestPanel added to UI but does not actually have the chest puzzle on it yet (this because it is assigned to a seperate issue #15). Panel currently looks like this:
![image](https://github.com/user-attachments/assets/de2266cb-a6c6-4a51-9e6a-d8dfac28f071)
